### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:edit]
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
 
   
 
@@ -34,7 +34,6 @@ def edit
 end
 
 def update
-  @item = Item.find(params[:id])
   if @item.update(item_params)
     redirect_to item_path
   else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,12 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:edit]
+  before_action :set_item, only: [:show, :edit]
+
+  
 
 
-  def index  # indexアクションを定義した
+
+  def index  
      @items = Item.order("created_at DESC")
   end
 
@@ -21,18 +25,16 @@ class ItemsController < ApplicationController
   end
 
  def show
-   @item = Item.find(params[:id])
+  
  end
 
 def edit
-   @item = Item.find(params[:id])
+   
    contributor_confirmation
 end
 
 def update
   @item = Item.find(params[:id])
-
-  # redirect_to item_path
   if @item.update(item_params)
     redirect_to item_path
   else
@@ -49,26 +51,11 @@ end
 
   def contributor_confirmation
     redirect_to root_path unless current_user == @item.user
-  
+  end
 
-    # if redirect_to root_path unless current_user == @item.user
-    # elsif redirect_to new_user_session_path unless user_signed_in?
-    # end
-  end  
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
-  # def move_to_index
-  #   unless user_signed_in?
-  #     redirect_to action: :index
-  #   end
-  # end
 end
-
-
-# <h3>編集する</h3>
-# <%= form_with(model: @tweet, local: true) do |form| %>
-#   <%= form.text_field :name, placeholder: "Nickname" %>
-#   <%= form.text_field :image, placeholder: "Image Url" %>
-#   <%= form.text_area :text, placeholder: "text", rows: "10" %>
-#   <%= form.submit "SEND" %>
-# <% end %>
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,14 @@ class ItemsController < ApplicationController
    @item = Item.find(params[:id])
  end
 
+def edit
+   @item = Item.find(params[:id])
+end
+
+def update
+  item = Item.find(params[:id])
+  item.update(item_params)
+end
 
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new,:edit]
 
 
   def index  # indexアクションを定義した
@@ -26,17 +26,35 @@ class ItemsController < ApplicationController
 
 def edit
    @item = Item.find(params[:id])
+   contributor_confirmation
 end
 
 def update
-  item = Item.find(params[:id])
-  item.update(item_params)
+  @item = Item.find(params[:id])
+
+  # redirect_to item_path
+  if @item.update(item_params)
+    redirect_to item_path
+  else
+    render :edit, status: :unprocessable_entity
+  end
+
 end
 
   private
   def item_params
     params.require(:item).permit(:image,:name, :explaination, :category_id, :condition_id,:del_fee_id,:prefecture_id,:days_until_shipping_id,:price,).merge(user_id: current_user.id)
   end
+
+
+  def contributor_confirmation
+    redirect_to root_path unless current_user == @item.user
+  
+
+    # if redirect_to root_path unless current_user == @item.user
+    # elsif redirect_to new_user_session_path unless user_signed_in?
+    # end
+  end  
 
   # def move_to_index
   #   unless user_signed_in?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,3 +44,13 @@ end
   #   end
   # end
 end
+
+
+# <h3>編集する</h3>
+# <%= form_with(model: @tweet, local: true) do |form| %>
+#   <%= form.text_field :name, placeholder: "Nickname" %>
+#   <%= form.text_field :image, placeholder: "Image Url" %>
+#   <%= form.text_area :text, placeholder: "text", rows: "10" %>
+#   <%= form.submit "SEND" %>
+# <% end %>
+

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,8 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
+    <%= form_with(model: @item, local: true) do |f| %>
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
@@ -23,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explaination, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id,Category.all, :id,:name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id,Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:del_fee_id, DelFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,10 +8,8 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @item, data: { turbo: false},local: true) do |f| %>
-    <%# <%= form_with(model: @item, local: true) do |f| %>
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# <%= render 'shared/error_messages', model: f.object %> 
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# <% <% <%= form_with(model: @item, local: true) do |f|  同じ記述か確認する  %> 
+
     <%= render 'shared/error_messages', model: @item %> 
 
     

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,14 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with(model: @item, local: true) do |f| %>
+    <%= form_with(model: @item, data: { turbo: false},local: true) do |f| %>
+    <%# <%= form_with(model: @item, local: true) do |f| %>
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%# <%= render 'shared/error_messages', model: f.object %> 
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: @item %> 
 
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -139,8 +142,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "送信する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     
    <% if user_signed_in?  %>
     <% if current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% else %>


### PR DESCRIPTION
What
商品情報編集機能設計

＃Why
商品情報編集の実装のため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/8984605b267efe56250e63e6f439619b


 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/b56013da3e6046d3fdee6aa0ec73b174


 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/4a9eb612bfcf49cd5a9a15004b25ed56

 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/a0673a679d9ed45ac462e02aaba8fbeb

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/86f52b4922f677f84e85e7adc8173da2

 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/d010442e9a536d0502f80b555fc7d6eb


 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/8984605b267efe56250e63e6f439619b
